### PR TITLE
Feat/aes256 encryption

### DIFF
--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -1,0 +1,27 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+)
+
+func GenerateAESKey() ([]byte, error) {
+	key := make([]byte, 32)
+	var err error
+	_, err = rand.Reader.Read(key)
+
+	return key, err
+}
+
+func GenerateCypherBlock(key []byte) (cipher.Block, error) {
+	block, err := aes.NewCipher(key)
+
+	return block, err
+}
+
+func GenerateGCM(block cipher.Block) (cipher.AEAD, error) {
+	gcm, err := cipher.NewGCM(block)
+
+	return gcm, err
+}

--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
 )
 
 func GenerateAESKey() ([]byte, error) {
@@ -14,13 +15,16 @@ func GenerateAESKey() ([]byte, error) {
 	return key, err
 }
 
-func GenerateCypherBlock(key []byte) (cipher.Block, error) {
+func GenerateCipherBlock(key []byte) (cipher.Block, error) {
 	block, err := aes.NewCipher(key)
 
 	return block, err
 }
 
 func GenerateGCM(block cipher.Block) (cipher.AEAD, error) {
+	if block == nil {
+		return nil, errors.New("cipher block is nil")
+	}
 	gcm, err := cipher.NewGCM(block)
 
 	return gcm, err

--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
 )
 
@@ -28,4 +29,21 @@ func GenerateGCM(block cipher.Block) (cipher.AEAD, error) {
 	gcm, err := cipher.NewGCM(block)
 
 	return gcm, err
+}
+
+func AESDecrypt(msg string, gcm cipher.AEAD) (string, error) {
+	ciphertext, err := base64.StdEncoding.DecodeString(msg)
+	nonceSize := gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return "", errors.New("encrypted message can't be shorter than nonce")
+	}
+
+	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+
 }

--- a/crypto/aes_test.go
+++ b/crypto/aes_test.go
@@ -1,0 +1,88 @@
+package crypto
+
+import (
+	"crypto/cipher"
+	"testing"
+)
+
+func TestGenerateAESKey(t *testing.T) {
+	key1, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(key1) != 32 {
+		t.Errorf("Expected key length 32, got %d", len(key1))
+	}
+
+	key2, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("Expected no error on second call, got %v", err)
+	}
+
+	if len(key2) != 32 {
+		t.Errorf("Expected key length 32 on second call, got %d", len(key2))
+	}
+
+	// Are keys different check (probability for them being same is insanely small)
+	if string(key1) == string(key2) {
+		t.Errorf("Expected different keys on subsequent calls, got identical keys")
+	}
+}
+
+func TestGenerateCipherBlock(t *testing.T) {
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	_, err = GenerateCipherBlock(key)
+	if err != nil {
+		t.Fatalf("Failed to generate cipher block with valid key %v", err)
+	}
+}
+
+func TestGenerateCipherBlock_EdgeCases(t *testing.T) {
+	// Key length 0 (nil)
+	_, err := GenerateCipherBlock(nil)
+	if err == nil {
+		t.Errorf("Expected error for nil key, got nil")
+	}
+
+	// Key length 10 (invalid length)
+	_, err = GenerateCipherBlock(make([]byte, 10))
+	if err == nil {
+		t.Errorf("Expected error for invalid key length 10, got nil")
+	}
+
+	// Key length 15 (invalid length)
+	_, err = GenerateCipherBlock(make([]byte, 15))
+	if err == nil {
+		t.Errorf("Expected error for invalid key length 15, got nil")
+	}
+}
+
+func TestGenerateGCM(t *testing.T) {
+	key, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("Failed to generate random key: %v", err)
+	}
+
+	block, err := GenerateCipherBlock(key)
+	if err != nil {
+		t.Fatalf("Failed to generate cipher block with valid key %v", err)
+	}
+
+	_, err = GenerateGCM(block)
+	if err != nil {
+		t.Fatalf("Failed to generate gcm with valid cipher block %v", err)
+	}
+}
+
+func TestGenerateGCM_EdgeCases(t *testing.T) {
+	var block cipher.Block = nil
+	_, err := GenerateGCM(block)
+	if err == nil {
+		t.Errorf("Expected error when passing nil cipher block, got nil")
+	}
+}

--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -82,3 +82,12 @@ func SendSignature(privKey *rsa.PrivateKey) (*models.DigitalSignatureMessage, er
 		Signature: signature,
 	}, nil
 }
+
+func Encrypt(data []byte, pubKey *rsa.PublicKey) (string, error) {
+	encryptedKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, data, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(encryptedKey), nil
+}

--- a/models/types.go
+++ b/models/types.go
@@ -8,3 +8,7 @@ type DigitalSignatureMessage struct {
 	Payload   string `json:"Payload"`
 	Signature string `json:"Signature"`
 }
+
+type LicenceMessage struct {
+	Uid string `json:"Uid"`
+}

--- a/server/aes_key.go
+++ b/server/aes_key.go
@@ -23,7 +23,7 @@ func (s *Server) HandleAESKey() gin.HandlerFunc {
 			return
 		}
 
-		s.CipherBlock, err = crypto.GenerateCypherBlock(s.Key)
+		s.CipherBlock, err = crypto.GenerateCipherBlock(s.Key)
 		if err != nil {
 			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return

--- a/server/aes_key.go
+++ b/server/aes_key.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/Stefan-Dr/GoGuard/crypto"
+	"github.com/gin-gonic/gin"
+)
+
+// The data we want to encrypt needs to be in []byte because AES required binary data
+
+func (s *Server) HandleAESKey() gin.HandlerFunc {
+	return func(context *gin.Context) {
+		var err error
+		s.Key, err = crypto.GenerateAESKey()
+		if err != nil {
+			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+			return
+		}
+
+		s.CipherBlock, err = crypto.GenerateCypherBlock(s.Key)
+		if err != nil {
+			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+			return
+		}
+
+		s.GCM, err = crypto.GenerateGCM(s.CipherBlock)
+		if err != nil {
+			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+			return
+		}
+	}
+}

--- a/server/aes_key.go
+++ b/server/aes_key.go
@@ -11,6 +11,11 @@ import (
 
 func (s *Server) HandleAESKey() gin.HandlerFunc {
 	return func(context *gin.Context) {
+		if s.ClientPublicKey == nil {
+			context.JSON(http.StatusBadRequest, gin.H{"Error": "Server doesn't have your public key yet"})
+			return
+		}
+
 		var err error
 		s.Key, err = crypto.GenerateAESKey()
 		if err != nil {
@@ -29,5 +34,13 @@ func (s *Server) HandleAESKey() gin.HandlerFunc {
 			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
 			return
 		}
+
+		encryptedKey, err := crypto.Encrypt(s.Key, s.ClientPublicKey)
+		if err != nil {
+			context.JSON(http.StatusInternalServerError, gin.H{"Error": err.Error()})
+			return
+		}
+
+		context.JSON(http.StatusOK, gin.H{"key": encryptedKey})
 	}
 }

--- a/server/digital_signature.go
+++ b/server/digital_signature.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) DigitalSignature() gin.HandlerFunc {
+func (s *Server) HandleDigitalSignature() gin.HandlerFunc {
 	return func(context *gin.Context) {
 		if s.ClientPublicKey == nil {
 			context.JSON(http.StatusBadRequest, gin.H{"error": "No Public Key visible for client"})

--- a/server/licence.go
+++ b/server/licence.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Stefan-Dr/GoGuard/crypto"
+	"github.com/Stefan-Dr/GoGuard/models"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) HandleLicence() gin.HandlerFunc {
+	return func(context *gin.Context) {
+		var msg models.LicenceMessage
+		if err := context.BindJSON(&msg); err != nil {
+			context.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+			return
+		}
+
+		uid, err := crypto.AESDecrypt(msg.Uid, s.GCM)
+		if err != nil {
+			context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
+
+		fmt.Print(uid)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -32,6 +32,7 @@ func (s *Server) RegisterRoutes() {
 	s.router.POST("/handshake", s.HandleHandshake())
 	s.router.POST("/digital-signature", s.HandleDigitalSignature())
 	s.router.GET("/get-key", s.HandleAESKey())
+	s.router.POST("/create-licence", s.HandleLicence())
 }
 
 func (s *Server) Start() {

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/cipher"
 	"crypto/rsa"
 	"net/http"
 
@@ -11,6 +12,9 @@ type Server struct {
 	router          *gin.Engine
 	ClientPublicKey *rsa.PublicKey
 	MyPrivateKey    *rsa.PrivateKey
+	Key             []byte
+	CipherBlock     cipher.Block
+	GCM             cipher.AEAD
 }
 
 func NewServer() *Server {
@@ -26,7 +30,8 @@ func (s *Server) RegisterRoutes() {
 		c.JSON(http.StatusOK, gin.H{"message": "pong"})
 	})
 	s.router.POST("/handshake", s.HandleHandshake())
-	s.router.POST("/digital-signature", s.DigitalSignature())
+	s.router.POST("/digital-signature", s.HandleDigitalSignature())
+	s.router.GET("/get-key", s.HandleAESKey())
 }
 
 func (s *Server) Start() {


### PR DESCRIPTION
# ✨ Summary  
This PR implements support for **AES-256-GCM encryption and decryption** between the client and server as part of the `/create-licence` flow.

# 🚀 Changes  
- The **client generates a random AES-256 key** and initializes an **AES-GCM cipher**.
- The **AES key is encrypted using RSA-OAEP with the client's public key**.
- The encrypted AES key is sent to the client, who decrypts it with their private RSA key.
- The client encrypts the **UID using AES-256-GCM** and sends it to the `/create-licence` endpoint.
- The server **decrypts the UID using the AES-GCM cipher** and outputs it for verification.

# 🔒 Why  
This adds secure symmetric encryption (AES-256-GCM) for sending sensitive data after the initial asymmetric handshake and digital signature (RSA-OAEP). AES is used because it is significantly faster than RSA for bulk data encryption, while RSA securely exchanges the AES key, combining efficiency with strong security. This enables efficient and secure communication after the key exchange.

# ✅ Closes  
Closes #5.
