### PR TITLE
feat: implement AES256 encryption for licence before sending to client

### DIFF
--- a/crypto/aes.go
+++ b/crypto/aes.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"io"
 )
 
 func GenerateAESKey() ([]byte, error) {
@@ -49,5 +50,17 @@ func AESDecrypt(msg string, gcm cipher.AEAD) (string, error) {
 	}
 
 	return string(plaintext), nil
+}
 
+func AESEncrypt(licence []byte, block cipher.Block, gcm cipher.AEAD) (string, error) {
+	nonce := make([]byte, 12)
+	_, err := io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return "", err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, licence, nil)
+	text := base64.StdEncoding.EncodeToString(ciphertext)
+
+	return text, nil
 }

--- a/server/licence.go
+++ b/server/licence.go
@@ -23,16 +23,25 @@ func (s *Server) HandleLicence() gin.HandlerFunc {
 		uid, err := crypto.AESDecrypt(msg.Uid, s.GCM)
 		if err != nil {
 			context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 
 		licence := sha256.Sum256([]byte(uid))
 		licenceString := base64.StdEncoding.EncodeToString(licence[:])
 
 		result, err := db.AddLicence(s.db, licenceString, uid)
-		if err != nil {
+		if err != nil || result == 0 {
 			fmt.Println(err.Error())
+			context.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
-		fmt.Println(result)
 
+		licenceEncrypted, err := crypto.AESEncrypt(licence[:], s.CipherBlock, s.GCM)
+		if err != nil {
+			if err != nil {
+				context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			}
+		}
+		context.JSON(http.StatusOK, gin.H{"licence": licenceEncrypted})
 	}
 }


### PR DESCRIPTION
- Implemented AES256 encryption for licence key using AES-GCM mode
- Generated random nonce for each encryption
- Encrypted licence is Base64 encoded and sent via HTTP response
- Added API response to return encrypted licence to client

Closes #12.