### PR TITLE
Test/unit tests

### DIFF
--- a/crypto/licence.go
+++ b/crypto/licence.go
@@ -3,9 +3,17 @@ package crypto
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 )
 
 func MakeUid(hwid string, key string) (string, error) {
+	if hwid == "" {
+		return "", errors.New("invalid hwid, empty string")
+	}
+	if key == "" {
+		return "", errors.New("invalid serve key, empty string")
+	}
+
 	root := key + hwid + key
 	rootBytes := []byte(root)
 

--- a/crypto/licence_test.go
+++ b/crypto/licence_test.go
@@ -1,0 +1,12 @@
+package crypto
+
+import (
+	"testing"
+)
+
+func TestMakeUid(t *testing.T) {
+	_, err := MakeUid("", "")
+	if err == nil {
+		t.Errorf("should return an error when trying to make a UID, when given an empty string as hwid or an empty server key, but got nil")
+	}
+}

--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -37,9 +37,12 @@ func GeneratePrivateKey() (*rsa.PrivateKey, error) {
 }
 
 func MakePublicKeyPEM(pvtKey *rsa.PrivateKey) ([]byte, error) {
+	if pvtKey == nil {
+		return nil, errors.New("can't make a PublicKeyPEM from nil")
+	}
 	pubKeyByte, err := x509.MarshalPKIXPublicKey(&pvtKey.PublicKey)
 	if err != nil {
-		return pubKeyByte, err
+		return nil, err
 	}
 
 	pubKeyPEM := pem.EncodeToMemory(&pem.Block{
@@ -84,6 +87,9 @@ func SendSignature(privKey *rsa.PrivateKey) (*models.DigitalSignatureMessage, er
 }
 
 func Encrypt(data []byte, pubKey *rsa.PublicKey) (string, error) {
+	if pubKey == nil {
+		return "", errors.New("can't encrypt with nil as publicKey")
+	}
 	encryptedKey, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, data, nil)
 	if err != nil {
 		return "", err

--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -54,6 +54,9 @@ func MakePublicKeyPEM(pvtKey *rsa.PrivateKey) ([]byte, error) {
 }
 
 func VerifySignature(clientMessage models.DigitalSignatureMessage, pubKey *rsa.PublicKey) error {
+	if pubKey == nil {
+		return errors.New("can't verify a signature with nil as publicKey")
+	}
 	payload := []byte(clientMessage.Payload)
 	hash := sha256.Sum256(payload)
 	var signatureBytes []byte
@@ -69,7 +72,10 @@ func VerifySignature(clientMessage models.DigitalSignatureMessage, pubKey *rsa.P
 	return err
 }
 
-func SendSignature(privKey *rsa.PrivateKey) (*models.DigitalSignatureMessage, error) {
+func MakeSignature(privKey *rsa.PrivateKey) (*models.DigitalSignatureMessage, error) {
+	if privKey == nil {
+		return nil, errors.New("can't make a signature with nil as private key")
+	}
 	payload := []byte("hello, world")
 
 	hash := sha256.Sum256(payload)

--- a/crypto/rsa_test.go
+++ b/crypto/rsa_test.go
@@ -55,7 +55,9 @@ func TestParseRSAPublicKeyFromPEM(t *testing.T) {
 
 	pubKey1 := &pvtKey1.PublicKey
 
-	if pubKey != pubKey1 {
+	// For RSA public keys, the only meaningful fields are N (the modulus, *big.Int) and E (the exponent, int).
+	// These fields uniquely define the key, so equality should be checked by comparing them, not by comparing pointers!
+	if pubKey.N.Cmp(pubKey1.N) != 0 || pubKey.E != pubKey1.E {
 		t.Errorf("Expected to get the same publicKey when applying MakePublicKeyPEM then ParseRSAPublicKeyFromPEM")
 	}
 }
@@ -71,6 +73,11 @@ func TestEncrypt(t *testing.T) {
 		t.Fatalf("Expected no error when getting publicKey from PublicKeyPEM , got %v", err)
 	}
 
+	_, err = Encrypt(nil, nil)
+	if err == nil {
+		t.Errorf("Expected error when encrypting nil key with nil as publicKey , but got no error")
+	}
+
 	_, err = Encrypt(aesKey, nil)
 	if err == nil {
 		t.Errorf("Expected error when encrypting AES256 key with nil as publicKey , but got no error")
@@ -79,5 +86,44 @@ func TestEncrypt(t *testing.T) {
 	_, err = Encrypt(aesKey, &pvtKey.PublicKey)
 	if err != nil {
 		t.Fatalf("Expected no error when encypting AES256 key with valid publicKey , got %v", err)
+	}
+}
+
+func TestMakeSignature(t *testing.T) {
+	_, err := MakeSignature(nil)
+	if err == nil {
+		t.Errorf("Expected an error when trying to sign string with nil, but got no error")
+	}
+
+	pvtKey, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error when creating privateKey , got %v", err)
+	}
+
+	_, err = MakeSignature(pvtKey)
+	if err != nil {
+		t.Errorf("Expected no error when trying to sign a string with a privateKey, but got %v", err)
+	}
+}
+
+func TestVerifySignature(t *testing.T) {
+	pvtKey, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error when creating privateKey , got %v", err)
+	}
+
+	signedMsg, err := MakeSignature(pvtKey)
+	if err != nil {
+		t.Errorf("Expected no error when trying to sign a string with a privateKey, but got %v", err)
+	}
+
+	err = VerifySignature(*signedMsg, nil)
+	if err == nil {
+		t.Errorf("Expected no error when verifying a message with nil as privateKey , but got no error")
+	}
+
+	err = VerifySignature(*signedMsg, &pvtKey.PublicKey)
+	if err != nil {
+		t.Errorf("Expected no error when trying to verify a signature with the same private/public key pair, but got %v", err)
 	}
 }

--- a/crypto/rsa_test.go
+++ b/crypto/rsa_test.go
@@ -1,0 +1,83 @@
+package crypto
+
+import (
+	"testing"
+)
+
+func TestGeneratePrivateKey(t *testing.T) {
+	pvtKey1, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error  when creating privateKey , got %v", err)
+	}
+
+	pvtKey2, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error  when creating privateKey , got %v", err)
+	}
+
+	if pvtKey1 == pvtKey2 {
+		t.Errorf("Expected different keys on subsequent calls, got identical keys")
+	}
+}
+
+func TestMakePublicKeyPEM(t *testing.T) {
+	pvtKey1, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error when creating privateKey , got %v", err)
+	}
+
+	_, err = MakePublicKeyPEM(pvtKey1)
+	if err != nil {
+		t.Fatalf("Expected no error when creating publicKeyPEM from a succesfully generated privateKey , got %v", err)
+	}
+
+	_, err = MakePublicKeyPEM(nil)
+	if err == nil {
+		t.Errorf("Expected error when making PublicKeyPEM from nil, but got no error")
+	}
+}
+
+func TestParseRSAPublicKeyFromPEM(t *testing.T) {
+	pvtKey1, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error when creating privateKey , got %v", err)
+	}
+
+	publicKeyPEM, err := MakePublicKeyPEM(pvtKey1)
+	if err != nil {
+		t.Fatalf("Expected no error when creating publicKeyPEM from a succesfully generated privateKey , got %v", err)
+	}
+
+	pubKey, err := ParseRSAPublicKeyFromPEM(string(publicKeyPEM))
+	if err != nil {
+		t.Fatalf("Expected no error when getting publicKey from PublicKeyPEM , got %v", err)
+	}
+
+	pubKey1 := &pvtKey1.PublicKey
+
+	if pubKey != pubKey1 {
+		t.Errorf("Expected to get the same publicKey when applying MakePublicKeyPEM then ParseRSAPublicKeyFromPEM")
+	}
+}
+
+func TestEncrypt(t *testing.T) {
+	pvtKey, err := GeneratePrivateKey()
+	if err != nil {
+		t.Fatalf("Expected no error when creating privateKey , got %v", err)
+	}
+
+	aesKey, err := GenerateAESKey()
+	if err != nil {
+		t.Fatalf("Expected no error when getting publicKey from PublicKeyPEM , got %v", err)
+	}
+
+	_, err = Encrypt(aesKey, nil)
+	if err == nil {
+		t.Errorf("Expected error when encrypting AES256 key with nil as publicKey , but got no error")
+	}
+
+	_, err = Encrypt(aesKey, &pvtKey.PublicKey)
+	if err != nil {
+		t.Fatalf("Expected no error when encypting AES256 key with valid publicKey , got %v", err)
+	}
+}

--- a/server/digital_signature.go
+++ b/server/digital_signature.go
@@ -53,7 +53,7 @@ func (s *Server) HandleDigitalSignature() gin.HandlerFunc {
 			return
 		}
 
-		serverResponse, err := crypto.SendSignature(session.MyPrivateKey)
+		serverResponse, err := crypto.MakeSignature(session.MyPrivateKey)
 		if err != nil {
 			log.Println("[ERROR] [" + ip + "] " + err.Error())
 			context.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})


### PR DESCRIPTION
## Summary  
This PR improves the `crypto/rsa` and `crypto/licence` packages by adding missing input validation and comprehensive unit tests for all core functions related to RSA encryption and digital signatures.

## What's been done  
### ✅ Added unit tests for:
- `ParseRSAPublicKeyFromPEM`
- `GeneratePrivateKey`
- `MakePublicKeyPEM`
- `Encrypt`
- `MakeSignature` (previously `SendSignature`)
- `VerifySignature`
- `MakeUid`

### 🛑 Added input validation (nil / empty checks) in:
- `MakeSignature`: now returns an error if `privKey` is `nil`
- `VerifySignature`: now returns an error if `pubKey` is `nil`
- `MakePublicKeyPEM`: now returns an error if `pvtKey` is `nil`
- `Encrypt`: now returns an error if `pubKey` is `nil`
- `MakeUid`: now returns an error if an empty string is passed

### 🔧 Refactoring:
- Renamed `SendSignature` to `MakeSignature` to better reflect its purpose.
- Improved existing test `TestParseRSAPublicKeyFromPEM`.

---

## Why this is needed  
- Ensures that invalid inputs are caught early with descriptive errors rather than causing runtime panics.  
- Improves test coverage and verifies the correctness of the cryptographic utility functions.  
- Clarifies function intent through naming (`MakeSignature`).  

---
